### PR TITLE
feat: Add toggle to restore scroll position for same locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ Default: true
 
 True to set Next.js Link default `scroll` property to `false`, false otherwise. Since the goal of this package is to manually control the scroll, you don't want Next.js default behavior of scrolling to top when clicking links.
 
+#### restoreSameLocation?
+
+Type: `boolean`   
+Default: false
+
+True to enable scroll restoration when the same location is navigated. By default, only going backwards and forward in the browser history will cause the scroll position to be restored.
+
 #### children
 
 Type: `ReactNode`

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,13 @@
   "packages": {
     "": {
       "name": "@moxy/next-router-scroll",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "history": "^3.0.0",
         "hoist-non-react-statics": "^3.3.2",
         "lodash": "^4.17.21",
+        "md5": "^2.3.0",
         "prop-types": "^15.7.2",
         "scroll-behavior": "^0.11.0"
       },
@@ -5412,6 +5413,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
@@ -6262,6 +6271,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/crypto-browserify": {
@@ -9879,8 +9896,7 @@
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-callable": {
       "version": "1.2.3",
@@ -13898,6 +13914,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/md5.js": {
@@ -25252,6 +25278,11 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "chokidar": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
@@ -25939,6 +25970,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -28726,8 +28762,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
       "version": "1.2.3",
@@ -31753,6 +31788,16 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "md5.js": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "history": "^3.0.0",
     "hoist-non-react-statics": "^3.3.2",
     "lodash": "^4.17.21",
+    "md5": "^2.3.0",
     "prop-types": "^15.7.2",
     "scroll-behavior": "^0.11.0"
   },

--- a/src/RouterScrollProvider.js
+++ b/src/RouterScrollProvider.js
@@ -27,31 +27,38 @@ const useDisableNextLinkScroll = (disableNextLinkScroll) => {
     }, [disableNextLinkScroll]);
 };
 
-const useScrollBehavior = (shouldUpdateScroll) => {
+const useScrollBehavior = (shouldUpdateScroll, restoreSameLocation) => {
     // Create NextScrollBehavior instance once.
     const shouldUpdateScrollRef = useRef();
     const scrollBehaviorRef = useRef();
 
     shouldUpdateScrollRef.current = shouldUpdateScroll;
 
+    useEffect(() => {
+        if (scrollBehaviorRef.current) {
+            scrollBehaviorRef.current.setRestoreSameLocation(restoreSameLocation);
+        }
+    }, [restoreSameLocation]);
+
     if (!scrollBehaviorRef.current) {
         scrollBehaviorRef.current = new NextScrollBehavior(
             (...args) => shouldUpdateScrollRef.current(...args),
+            restoreSameLocation,
         );
     }
 
-    // Destroy NextScrollBehavior instance when unmonting.
-    useEffect(() => () => scrollBehaviorRef.current.stop(), []);
+    // Destroy NextScrollBehavior instance when unmounting.
+    useEffect(() => () => scrollBehaviorRef.current?.stop(), []);
 
     return scrollBehaviorRef.current;
 };
 
-const ScrollBehaviorProvider = ({ disableNextLinkScroll, shouldUpdateScroll, children }) => {
+const ScrollBehaviorProvider = ({ disableNextLinkScroll, shouldUpdateScroll, restoreSameLocation, children }) => {
     // Disable next <Link> scroll or not.
     useDisableNextLinkScroll(disableNextLinkScroll);
 
     // Get the scroll behavior, creating it just once.
-    const scrollBehavior = useScrollBehavior(shouldUpdateScroll);
+    const scrollBehavior = useScrollBehavior(shouldUpdateScroll, restoreSameLocation);
 
     // Create facade to use as the provider value.
     const providerValue = useMemo(() => ({
@@ -75,6 +82,7 @@ ScrollBehaviorProvider.defaultProps = {
 ScrollBehaviorProvider.propTypes = {
     disableNextLinkScroll: PropTypes.bool,
     shouldUpdateScroll: PropTypes.func,
+    restoreSameLocation: PropTypes.bool,
     children: PropTypes.node,
 };
 

--- a/src/RouterScrollProvider.test.js
+++ b/src/RouterScrollProvider.test.js
@@ -5,6 +5,7 @@ import RouterScrollContext from './context';
 import RouterScrollProvider from './RouterScrollProvider';
 
 let mockNextScrollBehavior;
+let mockStateStorage;
 
 jest.mock('./scroll-behavior', () => {
     const NextScrollBehavior = jest.requireActual('./scroll-behavior');
@@ -23,6 +24,23 @@ jest.mock('./scroll-behavior', () => {
     }
 
     return SpiedNextScrollBehavior;
+});
+
+jest.mock('./scroll-behavior/StateStorage', () => {
+    const StateStorage = jest.requireActual('./scroll-behavior/StateStorage');
+
+    class SpiedStateStorage extends StateStorage {
+        constructor(...args) {
+            super(...args);
+
+            mockStateStorage = this; // eslint-disable-line consistent-this
+
+            jest.spyOn(this, 'save');
+            jest.spyOn(this, 'read');
+        }
+    }
+
+    return SpiedStateStorage;
 });
 
 afterEach(() => {
@@ -172,4 +190,52 @@ it('should allow changing shouldUpdateScroll', () => {
 
     expect(shouldUpdateScroll1).toHaveBeenCalledTimes(1);
     expect(shouldUpdateScroll2).toHaveBeenCalledTimes(1);
+});
+
+it('allows setting restoreSameLocation', () => {
+    const MyComponent = () => {
+        useContext(RouterScrollContext);
+
+        return null;
+    };
+
+    render(
+        <RouterScrollProvider>
+            <MyComponent />
+        </RouterScrollProvider>,
+    );
+
+    expect(mockStateStorage.restoreSameLocation).toBe(false);
+
+    render(
+        <RouterScrollProvider restoreSameLocation>
+            <MyComponent />
+        </RouterScrollProvider>,
+    );
+
+    expect(mockStateStorage.restoreSameLocation).toBe(true);
+});
+
+it('allows changing restoreSameLocation', () => {
+    const MyComponent = () => {
+        useContext(RouterScrollContext);
+
+        return null;
+    };
+
+    const { rerender } = render(
+        <RouterScrollProvider>
+            <MyComponent />
+        </RouterScrollProvider>,
+    );
+
+    expect(mockStateStorage.restoreSameLocation).toBe(false);
+
+    rerender(
+        <RouterScrollProvider restoreSameLocation>
+            <MyComponent />
+        </RouterScrollProvider>,
+    );
+
+    expect(mockStateStorage.restoreSameLocation).toBe(true);
 });

--- a/src/scroll-behavior/NextScrollBehavior.browser.js
+++ b/src/scroll-behavior/NextScrollBehavior.browser.js
@@ -12,9 +12,11 @@ export default class NextScrollBehavior extends ScrollBehavior {
     _context;
     _prevContext;
     _debounceSavePositionMap = new Map();
+    _stateStorage;
 
-    constructor(shouldUpdateScroll) {
+    constructor(shouldUpdateScroll, restoreSameLocation = false) {
         setupRouter();
+        const stateStorage = new StateStorage({ restoreSameLocation });
 
         super({
             addNavigationListener: (callback) => {
@@ -37,10 +39,11 @@ export default class NextScrollBehavior extends ScrollBehavior {
                 };
             },
             getCurrentLocation: () => this._context.location,
-            stateStorage: new StateStorage(),
+            stateStorage,
             shouldUpdateScroll,
         });
 
+        this._stateStorage = stateStorage;
         this._context = this._createContext();
         this._prevContext = null;
 
@@ -62,6 +65,10 @@ export default class NextScrollBehavior extends ScrollBehavior {
         };
 
         super.updateScroll(prevContext, context);
+    }
+
+    setRestoreSameLocation(newValue = false) {
+        this._stateStorage.restoreSameLocation = newValue;
     }
 
     stop() {

--- a/src/scroll-behavior/StateStorage.js
+++ b/src/scroll-behavior/StateStorage.js
@@ -1,9 +1,18 @@
 /* istanbul ignore file */
 import { readState, saveState } from 'history/lib/DOMStateStorage';
+import md5 from 'md5';
 
 const STATE_KEY_PREFIX = '@@scroll|';
 
+const hashLocation = (location) => md5(`${location.host}${location.pathname}${location.hash}${location.search}`);
+
 export default class StateStorage {
+    restoreSameLocation;
+
+    constructor({ restoreSameLocation }) {
+        this.restoreSameLocation = restoreSameLocation || false;
+    }
+
     read(location, key) {
         return readState(this.getStateKey(location, key));
     }
@@ -13,7 +22,8 @@ export default class StateStorage {
     }
 
     getStateKey(location, key) {
-        const locationKey = location.key ?? '_default';
+        const locationKey = this.restoreSameLocation ? hashLocation(location) : (location.key ?? '_default');
+
         const stateKeyBase = `${STATE_KEY_PREFIX}${locationKey}`;
 
         return key == null ? stateKeyBase : `${stateKeyBase}|${key}`;


### PR DESCRIPTION
Currently, the scroll restoration only gets restored when the history navigation (either backwards or forwards) is used. In my case, i want the scroll restoration to be restored when a link is clicked on the page that leads to the same location as well.

This PR adds a prop called `restoreSameLocation` to the `RouterScrollProvider`. `false` by default, it will enable this behavior if it is explicitly set.

Tests and documentation has been added as well. Let me know if anything is missing